### PR TITLE
Fix compiler warning

### DIFF
--- a/src/polling/providers/mod.rs
+++ b/src/polling/providers/mod.rs
@@ -10,7 +10,10 @@ use crate::shell::Shell;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+#[cfg(feature = "kubernetes")]
 use clap::{Clap, ValueHint};
+#[cfg(feature = "docker")]
+use clap::{Clap};
 use failure::{Error, Fail};
 use serde::{Serialize, Serializer};
 

--- a/src/polling/providers/mod.rs
+++ b/src/polling/providers/mod.rs
@@ -10,10 +10,10 @@ use crate::shell::Shell;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-#[cfg(feature = "kubernetes")]
-use clap::ValueHint;
 #[cfg(feature = "docker")]
 use clap::Clap;
+#[cfg(feature = "kubernetes")]
+use clap::ValueHint;
 use failure::{Error, Fail};
 use serde::{Serialize, Serializer};
 

--- a/src/polling/providers/mod.rs
+++ b/src/polling/providers/mod.rs
@@ -11,9 +11,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 #[cfg(feature = "kubernetes")]
-use clap::{Clap, ValueHint};
+use clap::ValueHint;
 #[cfg(feature = "docker")]
-use clap::{Clap};
+use clap::Clap;
 use failure::{Error, Fail};
 use serde::{Serialize, Serializer};
 

--- a/src/polling/providers/mod.rs
+++ b/src/polling/providers/mod.rs
@@ -10,7 +10,6 @@ use crate::shell::Shell;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-#[cfg(feature = "docker")]
 use clap::Clap;
 #[cfg(feature = "kubernetes")]
 use clap::ValueHint;


### PR DESCRIPTION
This changes fix the compilation warning:

```Shell
warning: unused import: `ValueHint`
  --> src/polling/providers/mod.rs:13:18
   |
13 | use clap::{Clap, ValueHint};
   |                  ^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: 1 warning emitted
```

when the source code will be compiled with feature "docker":

```Shell
cargo build --release --bins --package radvisor --no-default-features --features "docker"
```